### PR TITLE
feat(buoy): refactor to not require station_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+## 1.0.0 (UNRELEASED)
+
+### Buoy
+
+- **Realtime**: `get` returns `None` when data cannot be successfully retrieved.
+
+### Documentation
+
+- Update documentation and examples with revised syntax.
+
+## Breaking Changes
+
+### Buoy
+
+- **Realtime**: `Buoy` class instantiation no longer accepts arguments.
+  - `station_id` must now be provided as an argument for every request (see examples in docs).
+
+## 0.1.1 (2022-07-04)
+
+### Documentation
+
+- Add examples and installation instructions.
+
+## 0.1.0 (2022-07-04)
+
+🎉 **Initial release** 🎉
+
+## Features
+
+- Get realtime data for buoy by `station_id`.
+  - encapsulates realtime data with `Observation` class.
+- Get list of all active stations.
+
+## Internal
+
+- Incorporate githooks with `pre-commit` for development workflow.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For more information on what and how to work with poetry, [click here](https://r
 
 >>> from pybuoy import Buoy
 
->>> buoy = Buoy(station_id="44065")
+>>> buoy = Buoy()
 
 >>> buoy
 <pybuoy.buoy.Buoy object at 0x10481fc10>

--- a/docs/examples/get_activestations.py
+++ b/docs/examples/get_activestations.py
@@ -1,6 +1,6 @@
 from pybuoy import Buoy
 
-buoy = Buoy(station_id="44065")
+buoy = Buoy()
 
 active_stations = buoy.stations.get_active()
 

--- a/docs/examples/get_realtime_data.py
+++ b/docs/examples/get_realtime_data.py
@@ -1,8 +1,10 @@
 from pybuoy import Buoy
 
-buoy = Buoy(station_id="44065")
+buoy = Buoy()
 
-meteorological_dataset = "txt"
-realtime_meteorological_data = buoy.realtime.get(dataset=meteorological_dataset)
+example_station_id = "44065"
+
+# dataset="txt" is default
+realtime_meteorological_data = buoy.realtime.get(station_id=example_station_id)
 
 print(f"Station Realtime Data: \n----\n{realtime_meteorological_data}\n----\n")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "dev"
 optional = false
@@ -147,7 +147,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.19.0"
+version = "2.20.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -264,7 +264,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.15"
+version = "1.26.16"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -272,11 +272,11 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.10"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
@@ -304,12 +304,11 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "090c5bea08163298b80ccef9a806a8b5d0122c8bf50cf34185458c2997625d04"
+content-hash = "a7b889c1350a8a5632a3a1cbe12493b009dc732eebf812330d91f51bf541c4d0"
 
 [metadata.files]
 atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
@@ -368,8 +367,8 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.19.0-py2.py3-none-any.whl", hash = "sha256:10c62741aa5704faea2ad69cb550ca78082efe5697d6f04e5710c3c229afdd10"},
-    {file = "pre_commit-2.19.0.tar.gz", hash = "sha256:4233a1e38621c87d9dda9808c6606d7e7ba0e087cd56d3fe03202a01d2919615"},
+    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
+    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
@@ -439,12 +438,12 @@ types-requests = [
     {file = "types_requests-2.28.0-py3-none-any.whl", hash = "sha256:85383b4ef0535f639c3f06c5bbb6494bbf59570c4cd88bbcf540f0b2ac1b49ab"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.15.tar.gz", hash = "sha256:c89283541ef92e344b7f59f83ea9b5a295b16366ceee3f25ecfc5593c79f794e"},
-    {file = "types_urllib3-1.26.15-py3-none-any.whl", hash = "sha256:6011befa13f901fc934f59bb1fd6973be6f3acf4ebfce427593a27e7f492918f"},
+    {file = "types-urllib3-1.26.16.tar.gz", hash = "sha256:8bb3832c684c30cbed40b96e28bc04703becb2b97d82ac65ba4b968783453b0e"},
+    {file = "types_urllib3-1.26.16-py3-none-any.whl", hash = "sha256:20588c285e5ca336d908d2705994830a83cfb6bda40fc356bbafaf430a262013"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+    {file = "urllib3-1.26.10-py2.py3-none-any.whl", hash = "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec"},
+    {file = "urllib3-1.26.10.tar.gz", hash = "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"},
 ]
 virtualenv = [
     {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},

--- a/pybuoy/api/realtime.py
+++ b/pybuoy/api/realtime.py
@@ -3,11 +3,8 @@ from pybuoy.const import API_PATH, Endpoints
 
 
 class Realtime(ApiBase):
-    def __init__(self, station_id: str):
-        self.station_id = station_id
-
     # TODO: map phrases like "meterological" to appropriate dataset (i.e., "txt")
-    def get(self, dataset="txt"):
+    def get(self, station_id: str, dataset="txt"):
         """Get realtime data from the NDBC.
 
         There are six different data sources:
@@ -26,6 +23,9 @@ class Realtime(ApiBase):
             dataset (str): 'data_spec', 'ocean', 'spec', 'supl', 'swdir', 'swdir2', 'swr1',
                 'swr2', or 'txt'.
         """
+        if not station_id:
+            raise ValueError("station_id must be provided")
+
         dataset_options = {
             "data_spec",
             "ocean",
@@ -41,5 +41,5 @@ class Realtime(ApiBase):
         if dataset not in dataset_options:
             raise ValueError(f"Dataset must be one of {', '.join(dataset_options)}")
 
-        url = f"{API_PATH[Endpoints.REALTIME.value]}/{self.station_id}.{dataset}"
+        url = f"{API_PATH[Endpoints.REALTIME.value]}/{station_id}.{dataset}"
         return self.parse(self.make_request(url), dataset)

--- a/pybuoy/buoy.py
+++ b/pybuoy/buoy.py
@@ -6,20 +6,23 @@ class Buoy:
     """Buoy class provides convenient access to NDBC's API.
 
     Instances of this class are the gateway to interacting with National
-    Data Buoy Center (NDBC) through `buoypy`. The canonical way to obtain
+    Data Buoy Center (NDBC) through `pybuoy`. The canonical way to obtain
     an instance of this class is via:
 
     .. code-block:: python
 
         from pybuoy import Buoy
 
-        buoy = Buoy(station_id="44065")
-        buoy.realtime.get() # returns last 45 days of meteorological data
+        buoy = Buoy() # creates instance to access data from NDBC
+
+        realtime_meteorological_data = buoy.realtime.get(station_id="44065")
+
+        all_active_NDBC_stations = buoy.stations.get_active()
     """
 
     realtime: Realtime
     stations: Stations
 
-    def __init__(self, station_id: str):
-        self.realtime = Realtime(station_id=station_id)
+    def __init__(self):
+        self.realtime = Realtime()
         self.stations = Stations()

--- a/pybuoy/const.py
+++ b/pybuoy/const.py
@@ -1,4 +1,4 @@
-"""BuoyPy constants."""
+"""pybuoy constants."""
 from enum import Enum
 
 from .endpoints import API_PATH  # noqa: F401

--- a/pybuoy/mixins/parser.py
+++ b/pybuoy/mixins/parser.py
@@ -39,11 +39,13 @@ class ParserMixin:
         return data if dataset != "txt" else self.__clean_realtime_data(data=data)
 
     def _clean_activestation_data(self, data: str):
-
         xml_tree = et.fromstring(data)
         return [XmlToDict(el) for el in xml_tree.findall("station")]
 
     def __clean_realtime_data(self, data: str):
+        # TODO: Improve error handling when data is not successfully fetched
+        if data is None:
+            return None
         rows = data.strip().split("\n")
         headers = [" ".join(row.split()).split(" ") for row in rows[0:2]]
         realtime_data = []

--- a/pybuoy/observation.py
+++ b/pybuoy/observation.py
@@ -1,5 +1,5 @@
 class Observation(float):
-    """TBD."""
+    """Observation class encapsulates `Buoy` data by value, unit, and datetime recorded."""
 
     def __init__(self, value, label_and_unit, datetime=None):
         self.value = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-pre-commit = "^2.19.0"
+pre-commit = "^2.20.0"
 types-requests = "^2.28.0"
 
 [tool.black]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,5 @@ from pybuoy import Buoy
 
 # TODO: Mock Buoy endpoints
 @pytest.fixture(scope="module")
-def test_buoypy(station_id: str = "44065") -> Buoy:
-    return Buoy(station_id=station_id)
+def test_pybuoy() -> Buoy:
+    return Buoy()

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,8 +1,9 @@
 from pybuoy import Buoy, Observation
 
 
-def test_realtime_meterological_data(test_buoypy: Buoy):
-    response = test_buoypy.realtime.get()
+def test_realtime_meterological_data(test_pybuoy: Buoy):
+    example_station_id = "44065"
+    response = test_pybuoy.realtime.get(station_id=example_station_id)
     for record in response:
         assert isinstance(record[0], Observation)
         assert len(record) == 14  # typically 15, but datetime was abstracted into Observation

--- a/tests/test_stations.py
+++ b/tests/test_stations.py
@@ -4,8 +4,8 @@ from pybuoy import Buoy
 from pybuoy.mixins.parser import XmlToDict
 
 
-def test_activestations_from_xml(test_buoypy: Buoy):
-    response = test_buoypy.stations.get_active()
+def test_activestations_from_xml(test_pybuoy: Buoy):
+    response = test_pybuoy.stations.get_active()
 
     random_station = response[randrange(len(response))]
 


### PR DESCRIPTION
This PR introduces **BREAKING CHANGES**.

## Description

- Removes requirement to provide `station_id` when instantiating `Buoy` class.
- Improve error handling when fetching realtime data.

## Documentation

- `Buoy` no longer accepts arguments.
- Update `docs/examples`, code docstrings, and README to illustrate new syntax.
- Create `CHANGELOG` to track version changes.

## Related Issues

Closes #4 