### PR TITLE
feat(mypy): ship type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Realtime**: `get` returns list of `Observation` instances. Instance of `Observation` will default to `nan` (type: float) when datum is missing.
 
+### mypy
+
+- **Types**: provide type annotations to support static type checking.
+
 ### Internal
 
 - Add new `pre-commit` hooks and update all other hooks to latest version.

--- a/aliases
+++ b/aliases
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+#
+# Load scripts to current shell environment for execution without package manager.
+
+
+PROJECT_ROOT=$(realpath $(dirname "$BASH_SOURCE"))
+
+function bootstrap() {
+    ${PROJECT_ROOT}/scripts/bootstrap
+}
+function check() {
+    ${PROJECT_ROOT}/scripts/check
+}
+function clean() {
+    ${PROJECT_ROOT}/scripts/clean
+}
+function init() {
+    ${PROJECT_ROOT}/scripts/init
+}
+function lint() {
+    ${PROJECT_ROOT}/scripts/lint
+}
+function setup() {
+    ${PROJECT_ROOT}/scripts/setup
+}
+function start() {
+    ${PROJECT_ROOT}/scripts/start
+}
+function test() {
+    ${PROJECT_ROOT}/scripts/test
+}
+function uninstall() {
+    ${PROJECT_ROOT}/scripts/uninstall
+}
+
+echo 'Script commands are ready to use in current shell environment.'

--- a/poetry.lock
+++ b/poetry.lock
@@ -103,6 +103,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy"
+version = "0.971"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "nodeenv"
 version = "1.7.0"
 description = "Node.js virtual environment builder"
@@ -263,6 +289,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "typing-extensions"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "urllib3"
 version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -295,7 +329,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "a7b889c1350a8a5632a3a1cbe12493b009dc732eebf812330d91f51bf541c4d0"
+content-hash = "4db9d98105247340c3194528fe82d5b059a17a43365ce8241fab63bd86db96f6"
 
 [metadata.files]
 atomicwrites = [
@@ -340,6 +374,35 @@ idna = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+mypy = [
+    {file = "mypy-0.971-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"},
+    {file = "mypy-0.971-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5"},
+    {file = "mypy-0.971-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3"},
+    {file = "mypy-0.971-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655"},
+    {file = "mypy-0.971-cp310-cp310-win_amd64.whl", hash = "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103"},
+    {file = "mypy-0.971-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca"},
+    {file = "mypy-0.971-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417"},
+    {file = "mypy-0.971-cp36-cp36m-win_amd64.whl", hash = "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09"},
+    {file = "mypy-0.971-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8"},
+    {file = "mypy-0.971-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0"},
+    {file = "mypy-0.971-cp37-cp37m-win_amd64.whl", hash = "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2"},
+    {file = "mypy-0.971-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27"},
+    {file = "mypy-0.971-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856"},
+    {file = "mypy-0.971-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71"},
+    {file = "mypy-0.971-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27"},
+    {file = "mypy-0.971-cp38-cp38-win_amd64.whl", hash = "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58"},
+    {file = "mypy-0.971-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6"},
+    {file = "mypy-0.971-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe"},
+    {file = "mypy-0.971-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9"},
+    {file = "mypy-0.971-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf"},
+    {file = "mypy-0.971-cp39-cp39-win_amd64.whl", hash = "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0"},
+    {file = "mypy-0.971-py3-none-any.whl", hash = "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9"},
+    {file = "mypy-0.971.tar.gz", hash = "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nodeenv = [
     {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
@@ -427,6 +490,10 @@ types-requests = [
 types-urllib3 = [
     {file = "types-urllib3-1.26.22.tar.gz", hash = "sha256:b05af90e73889e688094008a97ca95788db8bf3736e2776fd43fb6b171485d94"},
     {file = "types_urllib3-1.26.22-py3-none-any.whl", hash = "sha256:09a8783e1002472e8d1e1f3792d4c5cca1fffebb9b48ee1512aae6d16fe186bc"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,27 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "black"
+version = "22.6.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -46,6 +67,17 @@ python-versions = ">=3.6.0"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -76,6 +108,19 @@ docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "flake8"
+version = "5.0.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.9.0,<2.10.0"
+pyflakes = ">=2.5.0,<2.6.0"
+
+[[package]]
 name = "identify"
 version = "2.5.3"
 description = "File identification library for Python"
@@ -101,6 +146,28 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "mypy"
@@ -146,6 +213,14 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "platformdirs"
@@ -194,6 +269,22 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.9.1"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyflakes"
+version = "2.5.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "pyparsing"
@@ -329,7 +420,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "4db9d98105247340c3194528fe82d5b059a17a43365ce8241fab63bd86db96f6"
+content-hash = "4ab2c0e1f9fb73476bf5513cd9fd544e9c22ef447547ee3cf6a310aac91fb7db"
 
 [metadata.files]
 atomicwrites = [
@@ -338,6 +429,31 @@ atomicwrites = [
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
@@ -351,6 +467,10 @@ charset-normalizer = [
     {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
     {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
@@ -363,6 +483,10 @@ filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
     {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
 ]
+flake8 = [
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+]
 identify = [
     {file = "identify-2.5.3-py2.py3-none-any.whl", hash = "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893"},
     {file = "identify-2.5.3.tar.gz", hash = "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"},
@@ -374,6 +498,14 @@ idna = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mypy = [
     {file = "mypy-0.971-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"},
@@ -412,6 +544,10 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
@@ -427,6 +563,14 @@ pre-commit = [
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+]
+pyflakes = [
+    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
+    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},

--- a/pybuoy/__init__.py
+++ b/pybuoy/__init__.py
@@ -1,3 +1,3 @@
-from pybuoy.buoy import Buoy  # noqa: F401
+from pybuoy.buoy import Buoy as Buoy  # noqa: F401
 from pybuoy.const import __version__  # noqa: F401
-from pybuoy.observation import Observation  # noqa: F401
+from pybuoy.observation import Observation as Observation  # noqa: F401

--- a/pybuoy/api/realtime.py
+++ b/pybuoy/api/realtime.py
@@ -1,5 +1,5 @@
 from pybuoy.api.base import ApiBase
-from pybuoy.const import API_PATH, Endpoints
+from pybuoy.const import API_PATH, REALTIME2
 
 
 class Realtime(ApiBase):
@@ -40,5 +40,5 @@ class Realtime(ApiBase):
         if dataset not in dataset_options:
             raise ValueError(f"Dataset must be one of {', '.join(dataset_options)}")
 
-        url = f"{API_PATH[Endpoints.REALTIME.value]}/{station_id}.{dataset}"
+        url = f"{API_PATH[REALTIME2]}/{station_id}.{dataset}"
         return self.parse(self.make_request(url), dataset)

--- a/pybuoy/api/stations.py
+++ b/pybuoy/api/stations.py
@@ -1,9 +1,9 @@
 from pybuoy.api.base import ApiBase
-from pybuoy.const import API_PATH, Endpoints
+from pybuoy.const import ACTIVE_STATIONS, API_PATH
 
 
 class Stations(ApiBase):
     def get_active(self):
         default_dataset = "xml"
-        url = f"{API_PATH[Endpoints.ACTIVE_STATIONS.value]}.{default_dataset}"
+        url = f"{API_PATH[ACTIVE_STATIONS]}.{default_dataset}"
         return self._clean_activestation_data(self.make_request(url))

--- a/pybuoy/const.py
+++ b/pybuoy/const.py
@@ -1,15 +1,7 @@
 """pybuoy constants."""
-from enum import Enum
-
-from pybuoy.endpoints import API_PATH  # noqa: F401
+from .endpoints import ACTIVE_STATIONS, API_PATH, REALTIME2  # noqa: F401
 
 __version__ = "0.2.0"
-
-
-class Endpoints(Enum):
-    ACTIVE_STATIONS = "active_stations"
-    REALTIME = "realtime2"
-
 
 #  Enable users to prepend user_agent
 # .format(user_agent)

--- a/pybuoy/endpoints.py
+++ b/pybuoy/endpoints.py
@@ -2,7 +2,7 @@
 
 BASE_URL = "https://www.ndbc.noaa.gov"
 
-ACTIVE_STATIONS = "activestations"
+ACTIVE_STATIONS = "active_stations"
 REALTIME2 = "realtime2"
 
 API_PATH: dict[str, str] = {

--- a/pybuoy/endpoints.py
+++ b/pybuoy/endpoints.py
@@ -2,6 +2,9 @@
 
 BASE_URL = "https://www.ndbc.noaa.gov"
 
+ACTIVE_STATIONS = "activestations"
+REALTIME2 = "realtime2"
+
 API_PATH: dict[str, str] = {
     "active_stations": f"{BASE_URL}/activestations",
     "realtime2": f"{BASE_URL}/data/realtime2",

--- a/pybuoy/mixins/parser.py
+++ b/pybuoy/mixins/parser.py
@@ -1,11 +1,12 @@
 """Provide the ParserMixin class."""
 from datetime import datetime as dt
-from xml.etree import cElementTree as et
+from xml.etree.cElementTree import fromstring
 
 from pybuoy.observation import Observation
 from pybuoy.unit_mappings import METEOROLOGICAL
 
 
+# TODO: set data's type to Element
 class XmlToDict(dict):
     def __init__(self, data):
         if data.items():
@@ -15,14 +16,13 @@ class XmlToDict(dict):
                 # treat like dict - assumes that if the first two tags
                 # in a series are different, then all are different.
                 if len(element) == 1 or element[0].tag != element[1].tag:
-                    tmp_dict = XmlToDict(element)
+                    tmp_dict: dict[str, XmlToDict] | XmlToDict = XmlToDict(element)
                 # treat like list - we assume that if the first two tags
                 # in a series are the same, then the rest are the same.
                 else:
-                    # TODO: fix inconsistency
                     tmp_dict = {element[0].tag: XmlToDict(element)}
-                # if the tag has attributes, add those to the dict.
-                if element.items():
+                # if the tag has attributes, add those to the dict
+                if isinstance(element, XmlToDict) and element.items():
                     tmp_dict.update(dict(element.items()))
                 self.update({element.tag: tmp_dict})
             # assumes an attribute in a tag without any text.
@@ -39,7 +39,7 @@ class ParserMixin:
         return data if dataset != "txt" else self.__clean_realtime_data(data=data)
 
     def _clean_activestation_data(self, data: str):
-        xml_tree = et.fromstring(data)
+        xml_tree = fromstring(data)
         return [XmlToDict(el) for el in xml_tree.findall("station")]
 
     def __clean_realtime_data(self, data: str):

--- a/pybuoy/unit_mappings.py
+++ b/pybuoy/unit_mappings.py
@@ -1,4 +1,4 @@
-"""WIP: Mapping key to unit for Observation."""
+"""Mapping key to unit for Observation."""
 
 # https://www.ndbc.noaa.gov/measdes.shtml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "Python wrapper for NDBC data."
 authors = ["Kyle J. Burda <kylejbdev@gmail.com>"]
 license = "GPL-3.0-or-later"
-readme = "README.md"
+readme = "docs/README.md"
 keywords=["NDBC", "NOAA", "api", "buoy", "weather", "wrapper"]
 classifiers=[
   "Operating System :: OS Independent",
@@ -26,6 +26,7 @@ requests = "^2.28.1"
 pytest = "^7.1.2"
 pre-commit = "^2.20.0"
 types-requests = "^2.28.0"
+mypy = "^0.971"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,23 @@ python = "^3.10"
 requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
+black = "^22.6.0"
+flake8 = "^5.0.4"
+isort = { version = "^5.10.1", extras = ["pyproject"]}
+mypy = "^0.971"
 pytest = "^7.1.2"
 pre-commit = "^2.20.0"
 types-requests = "^2.28.0"
-mypy = "^0.971"
+
+[tool.poetry.scripts]
+bootstrap="scripts.poetry_entrypoint:bootstrap"
+check="scripts.poetry_entrypoint:check"
+clean="scripts.poetry_entrypoint:clean"
+init="scripts.poetry_entrypoint:init"
+lint="scripts.poetry_entrypoint:lint"
+setup="scripts.poetry_entrypoint:setup"
+test="scripts.poetry_entrypoint:test"
+uninstall="scripts.poetry_entrypoint:uninstall"
 
 [tool.black]
 line-length = 88
@@ -44,6 +57,9 @@ exclude = '''
   )/
 )
 '''
+
+[tool.isort]
+profile="black"
 
 [tool.mypy]
 namespace_packages = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,41 @@
 
 These scripts are provided for development of [clairBuoyant](https://www.github.com/clairBuoyant). The script names are standardized across all repositories for clairBuoyant to simplify the development experience.
 
-## Avaliable Commands
+he command to run can be inferred based on the following pattern:
 
-_TBD_
+- command: `filename`
+  - e.g., `bootstrap`
+    - filename: bootstrap
+    - subFolderName: n/a
+
+## Available Commands
+
+See below for list of available commands.
+
+- `bootstrap`: resolve all system dependencies the application needs to run.
+- `check`: check whether code linting passes.
+- `clean`: remove all unnecessary build artifacts.
+- `init`: run bootstrap and setup.
+- `lint`: run code linting.
+- `setup`: install python dependencies and githooks.
+- `test`: run test suite.
+- `uninstall`: remove python dependencies and build artifacts.
+
+### Usage
+
+These scripts can be used directly or with `poetry` (**recommended**).
+
+1. Run with poetry: `poetry run <command_name>` (e.g., `poetry run init`) <sup>1</sup>
+2. Run directly:
+   - `./scripts/<filename>` (e.g., `./scripts/init` or `./scripts/check`)
+   - Run `. ./aliases` in your terminal to run any script just by `<command_name>` (e.g., `init` or `check`). <sup>2</sup>
+
+#### Note
+
+1. If you've ran `poetry shell` (i.e., if `which python` outputs "path/to/clairBuoyant/server/.venv/bin/python"), you could just run these scripts by `<command_name>` in terminal (e.g., `init` or `check`).
+
+2. Alternatively, you could run `. ./aliases`. This will load all command names to current shell, so you can call on these scripts by `<command_name>` (e.g., `init` or `check`). This script needs to be re-run every time you start a new terminal session. But, it saves you from prepending `poetry run` every time! :)
+
+### Attribution
+
+Styled after GitHub's ["Scripts to Rule Them All"](https://github.com/github/scripts-to-rule-them-all).

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#
+# Resolve all system dependencies the application needs to run.
+
+PYV=`python3 -c 'import sys; sys.stdout.write("true") if sys.version_info.major >= 3 and sys.version_info.minor >= 10 else sys.stdout.write("false");'`
+if ! $PYV
+then
+    echo 'Python version 3.10 or greater is required.'
+    exit 1
+fi
+
+echo 'Checking for poetry...'
+if ! command -v poetry &> /dev/null
+then
+    echo 'poetry was not found. Installing...'
+    curl -sSL https://install.python-poetry.org | python3 -
+fi
+
+echo 'System dependencies installed.'

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#
+# Check whether code linting passes.
+
+APP='pybuoy'
+
+if [ -d '.venv' ] ; then
+    PREFIX='.venv/bin/'
+else
+    PREFIX=''
+fi
+
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
+
+${PREFIX}black --check --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
+${PREFIX}isort --check --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
+${PREFIX}flake8 --config="${BASE_DIR}/.flake8" "${BASE_DIR}/${APP}"
+${PREFIX}mypy --config-file "${BASE_DIR}/pyproject.toml" -p "${APP}"

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+#
+# Remove all build artifacts.
+
+APP='pybuoy'
+
+if [ -d '.mypy_cache' ] ; then
+    rm -r .mypy_cache
+fi
+
+if [ -d '.pytest_cache' ] ; then
+    rm -r .pytest_cache
+fi
+
+if [ -d 'dist' ] ; then
+    rm -r dist
+fi
+
+if [ -d 'htmlcov' ] ; then
+    rm -r htmlcov
+fi
+
+find ${APP} -type d -name '__pycache__' | xargs -L1 rm -r

--- a/scripts/init
+++ b/scripts/init
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+#
+# Prepare application for development by running bootstrap and setup.
+
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
+
+${BASE_DIR}/scripts/bootstrap
+${BASE_DIR}/scripts/setup

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+#
+# Run code linting.
+
+APP='pybuoy'
+
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
+
+if [ -d '.venv' ] ; then
+    PREFIX='.venv/bin/'
+else
+    PREFIX=''
+fi
+
+${PREFIX}black --config "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
+${PREFIX}isort --settings-path "${BASE_DIR}/pyproject.toml" "${BASE_DIR}"
+${PREFIX}flake8 --config="${BASE_DIR}/.flake8" "${BASE_DIR}/${APP}"

--- a/scripts/poetry_entrypoint.py
+++ b/scripts/poetry_entrypoint.py
@@ -1,0 +1,11 @@
+from os import path
+from subprocess import call
+
+
+def __getattr__(name: str):
+    def execute_script():
+        dirname = path.dirname(__file__)
+        filename = path.join(dirname, name)
+        call(filename)
+
+    return execute_script

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+#
+# Install python dependencies and githooks.
+
+poetry install
+
+command -v pre-commit &> /dev/null && pre-commit install --hook-type commit-msg || echo >&2 'pre-commit not found.'

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+#
+# Run test suite.
+
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
+
+if [ -z "$GITHUB_ACTIONS" ]; then
+    ${BASE_DIR}/scripts/check
+fi
+
+if [ -d '.venv' ] ; then
+    PREFIX='.venv/bin/'
+else
+    PREFIX=''
+fi
+
+${PREFIX}/pytest

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+#
+# Remove all dependencies and build artifacts.
+
+./scripts/clean
+
+if [ -d '.venv' ] ; then
+    rm -r .venv
+fi


### PR DESCRIPTION
## Description

This PR adds `py.typed`, so `mypy` will know to use our type annotations. This means we don't have to maintain stub files in tandem, which is awesome!

### Internal Changes

- [x] Add `mypy` to dev dependencies for testing our type annotations.
- [x] Temporarily removed `Endpoints` as `Enum` and removed `Element` as type to circumvent type annotation complexity.
- [x] Add scripts to support development. Mimicking pattern and naming conventions established in [server](https://github.com/clairBuoyant/server/tree/main/scripts) and [web](https://github.com/clairBuoyant/web/tree/main/scripts).

## Related Issues

Closes #8