### PR TITLE
feat(api/realtime): set return type by dataset value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Types**: `realtime.get` [infers exact return type](https://github.com/clairBuoyant/pybuoy/pull/14#issue-1362358830) from user-provided value for `dataset`.
 
+### Internal
+
+- Bump all development dependencies to latest.
+
 ## 0.4.1 (2022-08-31)
 
 ### Observation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### mypy
+
+- **Types**: `realtime.get` [infers exact return type](https://github.com/clairBuoyant/pybuoy/pull/14#issue-1362358830) from user-provided value for `dataset`.
+
 ## 0.4.1 (2022-08-31)
 
 ### Observation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 - **Types**: `realtime.get` [infers exact return type](https://github.com/clairBuoyant/pybuoy/pull/14#issue-1362358830) from user-provided value for `dataset`.
 
+### ObservationDatum
+
+Refers to a particular piece of data from an `Observation` (e.g., wind_direction). Metadata can be accessed with `.label`, `.unit`, and `.value`. (e.g., `wind_direction.value`).
+
+- **ObservationFloatDatum**: validate numeric values (previously named `ObservationDatum`).
+- **ObservationStringDatum**: validate non-numeric values.
+
+### Observation
+
+Weather <u>observation</u> recorded at unique datetime by type of `dataset` (e.g., meteorological).
+
+- **MeteorologicalObservation**: attributes return either `ObservationFloatDatum` or `ObservationStringDatum` after validating data provided from NDBC.
+- **WaveSummaryObservation**: attributes return either `ObservationFloatDatum` or `ObservationStringDatum` after validating data provided from NDBC.
+
+### Observations
+
+The following models were extended from `Observations` to support static typing:
+
+- **MeteorologicalObservations**: can use `+=` syntax on an instance of this class in order to append `MeteorologicalObservation` records.
+- **WaveSummaryObservations**: can use `+=` syntax on an instance of this class in order to append `WaveSummaryObservation` records.
+
 ### Internal
 
 - Bump all development dependencies to latest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Internal
 
 - Bump all development dependencies to latest.
+- Extend tests to check for expected attributes and types.
 
 ## 0.4.1 (2022-08-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Internal
 
 - Bump all development dependencies to latest.
-- Extend tests to check for expected attributes and types.
+- Extend tests to check for expected attributes. [TODO: add type checks]
 
 ## 0.4.1 (2022-08-31)
 

--- a/docs/examples/get_realtime_data.py
+++ b/docs/examples/get_realtime_data.py
@@ -5,14 +5,13 @@ buoy = Buoy()
 example_station_id = "44065"
 
 # dataset="txt" is default
-realtime_meteorological_data = buoy.realtime.get(
-    station_id=example_station_id, dataset="txt"
-)
+realtime_meteorological_data = buoy.realtime.get(station_id=example_station_id)
 
 for meteorological_record in realtime_meteorological_data:
     # IDE should now detect available attributes
     # add code below here
-    ...
+    pass
+
 # Sample Output of Meteorological Data
 print(f"Station Realtime Data (latest record): {realtime_meteorological_data[0]}")
 # OUTPUT: Station Realtime Data (latest record): Observation(2022-08-28 21:10:00) # noqa: E501,W505

--- a/docs/examples/get_realtime_data.py
+++ b/docs/examples/get_realtime_data.py
@@ -1,31 +1,23 @@
 from pybuoy import Buoy
-from pybuoy.observation.observation import (
-    MeteorologicalObservation,
-    WaveSummaryObservation,
-)
 
 buoy = Buoy()
 
 example_station_id = "44065"
 
 # dataset="txt" is default
-realtime_meteorological_data = buoy.realtime.get(station_id=example_station_id)
+realtime_meteorological_data = buoy.realtime.get(
+    station_id=example_station_id, dataset="txt"
+)
 
-for record in realtime_meteorological_data:
-    # add to support your editor's intellisense with this check
-    is_meteorological = isinstance(record, MeteorologicalObservation)
-    if not is_meteorological:
-        break
-    # IDE will now detect available attributes
-    # when interacting with the iterator variable (record)
-
+for meteorological_record in realtime_meteorological_data:
+    # IDE should now detect available attributes
     # add code below here
-
+    ...
 # Sample Output of Meteorological Data
 print(f"Station Realtime Data (latest record): {realtime_meteorological_data[0]}")
 # OUTPUT: Station Realtime Data (latest record): Observation(2022-08-28 21:10:00) # noqa: E501,W505
 #
-"""realtime_meteorological_data returns an instance of `Observations`.
+"""realtime_meteorological_data returns an instance of `MeteorologicalObservations`.
 `Observations` is an iterable object and contains a list
 of `MeteorologicalObservation`.
 
@@ -54,27 +46,20 @@ Under the hood, the aforementioned sample output provides this object:
 """  # noqa: W505
 
 
-wave_summary = "spec"
-
 realtime_wave_summary_data = buoy.realtime.get(
-    station_id=example_station_id, dataset=wave_summary
+    station_id=example_station_id, dataset="spec"
 )
 
-for record in realtime_wave_summary_data:
-    # add to support your editor's intellisense with this check
-    is_wave_summary = isinstance(record, WaveSummaryObservation)
-    if not is_wave_summary:
-        break
-    # IDE will now detect available attributes
-    # when interacting with the iterator variable (record)
+for wave_record in realtime_wave_summary_data:
+    # IDE should now detect available attributes
     # add code below here
-
+    pass
 
 # Sample Output of Wave Summary Data
 print(f"Station Realtime Data (latest record): {realtime_wave_summary_data[0]}")
 # OUTPUT: Station Realtime Data (latest record): Observation(2022-08-28 20:40:00) # noqa: E501,W505
 #
-"""realtime_wave_summary_data returns an instance of `Observations`.
+"""realtime_wave_summary_data returns an instance of `WaveSummaryObservations`.
 `Observations` is an iterable object and contains a list
 of `WaveSummaryObservation`.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -15,14 +7,14 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "black"
-version = "22.6.0"
+version = "22.8.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -122,7 +114,7 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "identify"
-version = "2.5.3"
+version = "2.5.4"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -156,10 +148,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "mccabe"
@@ -203,6 +195,9 @@ category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 
+[package.dependencies]
+setuptools = "*"
+
 [[package]]
 name = "packaging"
 version = "21.3"
@@ -216,11 +211,11 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
@@ -231,8 +226,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -295,18 +290,17 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
@@ -319,7 +313,7 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
-name = "pyyaml"
+name = "PyYAML"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "dev"
@@ -343,6 +337,19 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "setuptools"
+version = "65.3.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "toml"
@@ -396,13 +403,13 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.3"
+version = "20.16.4"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -420,40 +427,37 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "4ab2c0e1f9fb73476bf5513cd9fd544e9c22ef447547ee3cf6a310aac91fb7db"
+content-hash = "d0d8e8e6024e959eecc25ffad3dcf8d82f8ac97c8f73dfbc3071f16603f2997f"
 
 [metadata.files]
-atomicwrites = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 black = [
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
-    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
-    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
-    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
-    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
-    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
-    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
-    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
-    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
-    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
-    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
-    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
-    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
-    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
-    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
-    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
-    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
-    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27"},
+    {file = "black-22.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747"},
+    {file = "black-22.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869"},
+    {file = "black-22.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90"},
+    {file = "black-22.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe"},
+    {file = "black-22.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342"},
+    {file = "black-22.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab"},
+    {file = "black-22.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3"},
+    {file = "black-22.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e"},
+    {file = "black-22.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5"},
+    {file = "black-22.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411"},
+    {file = "black-22.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3"},
+    {file = "black-22.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497"},
+    {file = "black-22.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c"},
+    {file = "black-22.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41"},
+    {file = "black-22.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec"},
+    {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
+    {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
@@ -488,8 +492,8 @@ flake8 = [
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
 identify = [
-    {file = "identify-2.5.3-py2.py3-none-any.whl", hash = "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893"},
-    {file = "identify-2.5.3.tar.gz", hash = "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"},
+    {file = "identify-2.5.4-py2.py3-none-any.whl", hash = "sha256:962d9bec27ccd1fcceff9b11f8c635afeb163ea3d8b6b30d8f1eee37ec7fac47"},
+    {file = "identify-2.5.4.tar.gz", hash = "sha256:b020e876cec2b11dadb3324fa0427eb744b7d66ef19ac579a748dfff774b6dcf"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -545,8 +549,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -577,10 +581,10 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
-    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
 ]
-pyyaml = [
+PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -619,6 +623,10 @@ requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
+setuptools = [
+    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
+    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -644,6 +652,6 @@ urllib3 = [
     {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.16.3-py2.py3-none-any.whl", hash = "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1"},
-    {file = "virtualenv-20.16.3.tar.gz", hash = "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"},
+    {file = "virtualenv-20.16.4-py3-none-any.whl", hash = "sha256:035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22"},
+    {file = "virtualenv-20.16.4.tar.gz", hash = "sha256:014f766e4134d0008dcaa1f95bafa0fb0f575795d07cae50b1bee514185d6782"},
 ]

--- a/pybuoy/api/realtime.py
+++ b/pybuoy/api/realtime.py
@@ -1,7 +1,7 @@
 from typing import Literal, overload
 
 from pybuoy.api.base import ApiBase
-from pybuoy.const import API_PATH, Endpoints
+from pybuoy.const import API_PATH, Endpoints, RealtimeDatasets, RealtimeDatasetsValues
 from pybuoy.observation.observations import (
     MeteorologicalObservations,
     WaveSummaryObservations,
@@ -11,20 +11,24 @@ from pybuoy.observation.observations import (
 class Realtime(ApiBase):
     @overload
     def get(
-        self, station_id: str, dataset: Literal["txt"]
-    ) -> MeteorologicalObservations:
-        ...
-
-    @overload
-    def get(
         self,
         station_id: str,
         dataset: Literal["spec"],
     ) -> WaveSummaryObservations:
         ...
 
-    # TODO: map phrases like "meterological" to dataset (i.e., "txt")
-    def get(self, station_id: str, dataset="txt"):
+    @overload
+    def get(
+        self, station_id: str, dataset: Literal["txt"] = "txt"
+    ) -> MeteorologicalObservations:
+        ...
+
+    # TODO: consider mapping str literal to dataset
+    def get(
+        self,
+        station_id: str,
+        dataset: RealtimeDatasetsValues = RealtimeDatasets.txt.value,
+    ):
         """Get realtime data from the NDBC.
 
         There are six different data sources:
@@ -62,18 +66,4 @@ class Realtime(ApiBase):
 
         url = f"{API_PATH[Endpoints.REALTIME.value]}/{station_id}.{dataset}"
 
-        # TODO: rework approach for dynamic typing
-        if dataset == "spec":
-            x: WaveSummaryObservations = self.parse(
-                self.make_request(url),
-                "spec",
-                WaveSummaryObservations,
-            )
-            return x
-        if dataset == "txt":
-            y: MeteorologicalObservations = self.parse(
-                self.make_request(url),
-                "txt",
-                MeteorologicalObservations,
-            )
-            return y
+        return self.parse(data=self.make_request(url), dataset=dataset)

--- a/pybuoy/api/realtime.py
+++ b/pybuoy/api/realtime.py
@@ -1,8 +1,28 @@
+from typing import Literal, overload
+
 from pybuoy.api.base import ApiBase
 from pybuoy.const import API_PATH, Endpoints
+from pybuoy.observation.observations import (
+    MeteorologicalObservations,
+    WaveSummaryObservations,
+)
 
 
 class Realtime(ApiBase):
+    @overload
+    def get(
+        self, station_id: str, dataset: Literal["txt"]
+    ) -> MeteorologicalObservations:
+        ...
+
+    @overload
+    def get(
+        self,
+        station_id: str,
+        dataset: Literal["spec"],
+    ) -> WaveSummaryObservations:
+        ...
+
     # TODO: map phrases like "meterological" to dataset (i.e., "txt")
     def get(self, station_id: str, dataset="txt"):
         """Get realtime data from the NDBC.
@@ -41,4 +61,19 @@ class Realtime(ApiBase):
             raise ValueError(f"Dataset must be one of {', '.join(dataset_options)}")
 
         url = f"{API_PATH[Endpoints.REALTIME.value]}/{station_id}.{dataset}"
-        return self.parse(self.make_request(url), dataset)
+
+        # TODO: rework approach for dynamic typing
+        if dataset == "spec":
+            x: WaveSummaryObservations = self.parse(
+                self.make_request(url),
+                "spec",
+                WaveSummaryObservations,
+            )
+            return x
+        if dataset == "txt":
+            y: MeteorologicalObservations = self.parse(
+                self.make_request(url),
+                "txt",
+                MeteorologicalObservations,
+            )
+            return y

--- a/pybuoy/const.py
+++ b/pybuoy/const.py
@@ -1,5 +1,6 @@
 """pybuoy constants."""
 from enum import Enum
+from typing import Literal, Union
 
 from pybuoy.endpoints import API_PATH as API_PATH  # noqa: F401
 
@@ -10,9 +11,11 @@ class Endpoints(Enum):
 
 
 class RealtimeDatasets(Enum):
-    SPEC = "spec"
-    TXT = "txt"
+    spec = "spec"
+    txt = "txt"
 
+
+RealtimeDatasetsValues = Union[RealtimeDatasets, Literal["spec", "txt"]]
 
 NO_VALUE = "MM"
 

--- a/pybuoy/const.py
+++ b/pybuoy/const.py
@@ -1,6 +1,6 @@
 """pybuoy constants."""
 from enum import Enum
-from typing import Literal, Union
+from typing import Literal
 
 from pybuoy.endpoints import API_PATH as API_PATH  # noqa: F401
 
@@ -11,12 +11,27 @@ class Endpoints(Enum):
 
 
 class RealtimeDatasets(Enum):
+    data_spec = "data_spec"
+    ocean = "ocean"
     spec = "spec"
+    supl = "supl"
+    swdir = "swdir"
+    swdir2 = "swdir2"
+    swr1 = "swr1"
+    swr2 = "swr2"
     txt = "txt"
 
 
-RealtimeDatasetsValues = Union[RealtimeDatasets, Literal["spec", "txt"]]
-
-NO_VALUE = "MM"
+RealtimeDatasetsValues = Literal[
+    "data_spec",
+    "ocean",
+    "spec",
+    "supl",
+    "swdir",
+    "swdir2",
+    "swr1",
+    "swr2",
+    "txt",
+]
 
 __version__ = "0.4.0"

--- a/pybuoy/mixins/parser.py
+++ b/pybuoy/mixins/parser.py
@@ -1,12 +1,13 @@
 """Provide the ParserMixin class."""
 from datetime import datetime as dt
+from typing import Literal, Type, TypeVar, Union, overload
 from xml.etree.cElementTree import Element, fromstring
 
-from pybuoy.const import RealtimeDatasets
-from pybuoy.observation import (
-    MeteorologicalObservation,
-    Observations,
-    WaveSummaryObservation,
+from pybuoy.const import RealtimeDatasets, RealtimeDatasetsValues
+from pybuoy.observation import MeteorologicalObservation, WaveSummaryObservation
+from pybuoy.observation.observations import (
+    MeteorologicalObservations,
+    WaveSummaryObservations,
 )
 from pybuoy.unit_mappings import MeteorologicalKey, WaveSummaryKey
 
@@ -36,22 +37,73 @@ class XmlToDict(dict):
                 self.update({element.tag: element.text})
 
 
+T = TypeVar("T")
+
+
 class ParserMixin:
     """Interface for Buoy classes and its composites."""
 
-    def parse(self, data: str, dataset: str = RealtimeDatasets.TXT.value):
-        return (
-            data
-            if dataset != RealtimeDatasets.TXT.value
-            and dataset != RealtimeDatasets.SPEC.value
-            else self.__clean_realtime_data(data=data, dataset=dataset)
-        )
+    @overload
+    def parse(
+        self,
+        data: str,
+        dataset: Literal["txt"],
+        __observation_type: Type[MeteorologicalObservations],
+    ) -> MeteorologicalObservations:
+        ...
+
+    @overload
+    def parse(
+        self,
+        data: str,
+        dataset: Literal["spec"],
+        __observation_type: Type[WaveSummaryObservations],
+    ) -> WaveSummaryObservations:
+        ...
+
+    @overload
+    def parse(
+        self, data: str, dataset: RealtimeDatasetsValues, __observation_type: Type[str]
+    ) -> str:
+        ...
+
+    # TODO: rework signature
+    def parse(
+        self,
+        data: str,
+        dataset: RealtimeDatasetsValues,
+        __observation_type: Type[T],
+    ):
+        observations_class_instance = __observation_type()
+        if isinstance(observations_class_instance, MeteorologicalObservations):
+            return self.__clean_realtime_data(
+                data, RealtimeDatasets.txt.value, observations_class_instance
+            )
+        if isinstance(observations_class_instance, WaveSummaryObservations):
+            return self.__clean_realtime_data(
+                data, RealtimeDatasets.spec.value, observations_class_instance
+            )
+        return data
 
     def _clean_activestation_data(self, data: str):
         xml_tree = fromstring(data)
         return [XmlToDict(el) for el in xml_tree.findall("station")]
 
-    def __clean_realtime_data(self, data: str, dataset: str) -> Observations:
+    @overload
+    def __clean_realtime_data(
+        self, data: str, dataset: Literal["txt"], t: MeteorologicalObservations
+    ) -> MeteorologicalObservations:
+        ...
+
+    @overload
+    def __clean_realtime_data(
+        self, data: str, dataset: Literal["spec"], t: WaveSummaryObservations
+    ) -> WaveSummaryObservations:
+        ...
+
+    def __clean_realtime_data(
+        self, data: str, dataset: Union[Literal["txt"], Literal["spec"]], t: T
+    ):
         # TODO: Error handling when request not successful
         if data is None:
             return None
@@ -62,7 +114,7 @@ class ParserMixin:
         headers_without_dates = headers[0][header_offset:]
 
         # TODO: consider csv module
-        realtime_data = Observations()
+        realtime_data = t
         for row in rows[2:]:
             record_array = " ".join(row.split()).split(" ")
             date_recorded = dt(
@@ -75,7 +127,7 @@ class ParserMixin:
 
             observation: MeteorologicalObservation | WaveSummaryObservation
             values: dict[MeteorologicalKey, str] | dict[WaveSummaryKey, str]
-            if dataset == RealtimeDatasets.TXT.value:
+            if dataset == RealtimeDatasets.txt.value:
                 values = {
                     MeteorologicalKey[headers_without_dates[idx]]: value
                     for idx, value in enumerate(record_array[header_offset:])
@@ -84,7 +136,7 @@ class ParserMixin:
                     values,
                     date_recorded,
                 )
-            elif dataset == RealtimeDatasets.SPEC.value:
+            elif dataset == RealtimeDatasets.spec.value:
                 values = {
                     WaveSummaryKey[headers_without_dates[idx]]: value
                     for idx, value in enumerate(record_array[header_offset:])
@@ -93,8 +145,8 @@ class ParserMixin:
                     values,
                     date_recorded,
                 )
-            # TODO: refactor to use setter method
-            realtime_data.reports.append(
+            # TODO: refactor to use setter method and fix type
+            realtime_data.reports.append(  # type: ignore
                 observation
             ) if observation is not None else None
         return realtime_data

--- a/pybuoy/observation/__init__.py
+++ b/pybuoy/observation/__init__.py
@@ -4,4 +4,7 @@ from pybuoy.observation.observation_datum import (  # noqa: F401
     ObservationFloatDatum,
     ObservationStringDatum,
 )
-from pybuoy.observation.observations import Observations  # noqa: F401
+from pybuoy.observation.observations import (  # noqa: F401
+    MeteorologicalObservations,
+    WaveSummaryObservations,
+)

--- a/pybuoy/observation/observation.py
+++ b/pybuoy/observation/observation.py
@@ -69,74 +69,74 @@ class MeteorologicalObservation(BaseObservation):
             )
 
     @property
-    def wind_direction(self):
+    def wind_direction(self) -> ObservationFloatDatum:
         """Return observed wind direction."""
-        return self._wind_direction
+        return self._wind_direction  # type: ignore # this is dynamically set
 
     @property
-    def wind_speed(self):
+    def wind_speed(self) -> ObservationFloatDatum:
         """Return observed wind speed."""
-        return self._wind_speed
+        return self._wind_speed  # type: ignore # this is dynamically set
 
     @property
-    def wind_gust(self):
+    def wind_gust(self) -> ObservationFloatDatum:
         """Return observed wind gust."""
-        return self._wind_gust
+        return self._wind_gust  # type: ignore # this is dynamically set
 
     @property
-    def wave_height(self):
+    def wave_height(self) -> ObservationFloatDatum:
         """Return observed wave height."""
-        return self._wave_height
+        return self._wave_height  # type: ignore # this is dynamically set
 
     @property
-    def dominant_wave_period(self):
+    def dominant_wave_period(self) -> ObservationFloatDatum:
         """Return observed dominant wave period."""
-        return self._dominant_wave_period
+        return self._dominant_wave_period  # type: ignore # this is dynamically set
 
     @property
-    def average_wave_period(self):
+    def average_wave_period(self) -> ObservationFloatDatum:
         """Return observed average wave period."""
-        return self._average_wave_period
+        return self._average_wave_period  # type: ignore # this is dynamically set
 
     @property
-    def wave_direction(self):
+    def wave_direction(self) -> ObservationFloatDatum:
         """Return observed wave direction."""
-        return self._wave_direction
+        return self._wave_direction  # type: ignore # this is dynamically set
 
     @property
-    def sea_level_pressure(self):
+    def sea_level_pressure(self) -> ObservationFloatDatum:
         """Return observed sea level pressure."""
-        return self._sea_level_pressure
+        return self._sea_level_pressure  # type: ignore # this is dynamically set
 
     @property
-    def air_temperature(self):
+    def air_temperature(self) -> ObservationFloatDatum:
         """Return observed air temperature."""
-        return self._air_temperature
+        return self._air_temperature  # type: ignore # this is dynamically set
 
     @property
-    def water_temperature(self):
+    def water_temperature(self) -> ObservationFloatDatum:
         """Return observed water temperature."""
-        return self._water_temperature
+        return self._water_temperature  # type: ignore # this is dynamically set
 
     @property
-    def dewpoint_temperature(self):
+    def dewpoint_temperature(self) -> ObservationFloatDatum:
         """Return observed dewpoint temperature."""
-        return self._dewpoint_temperature
+        return self._dewpoint_temperature  # type: ignore # this is dynamically set
 
     @property
-    def visibility(self):
+    def visibility(self) -> ObservationFloatDatum:
         """Return observed visibility."""
-        return self._visibility
+        return self._visibility  # type: ignore # this is dynamically set
 
     @property
-    def pressure_tendency(self):
+    def pressure_tendency(self) -> ObservationFloatDatum:
         """Return observed pressure tendency."""
-        return self._pressure_tendency
+        return self._pressure_tendency  # type: ignore # this is dynamically set
 
     @property
-    def tide(self):
+    def tide(self) -> ObservationFloatDatum:
         """Return observed tide."""
-        return self._tide
+        return self._tide  # type: ignore # this is dynamically set
 
 
 class WaveSummaryObservation(BaseObservation):
@@ -168,51 +168,51 @@ class WaveSummaryObservation(BaseObservation):
             )
 
     @property
-    def significant_wave_height(self):
+    def significant_wave_height(self) -> ObservationFloatDatum:
         """Return observed wave height."""
-        return self._significant_wave_height
+        return self._significant_wave_height  # type: ignore # this is dynamically set
 
     @property
-    def swell_height(self):
+    def swell_height(self) -> ObservationFloatDatum:
         """Return observed swell height."""
-        return self._swell_height
+        return self._swell_height  # type: ignore # this is dynamically set
 
     @property
-    def swell_period(self):
+    def swell_period(self) -> ObservationFloatDatum:
         """Return observed swell period."""
-        return self._swell_period
+        return self._swell_period  # type: ignore # this is dynamically set
 
     @property
-    def wind_wave_height(self):
+    def wind_wave_height(self) -> ObservationFloatDatum:
         """Return observed wind wave height."""
-        return self._wind_wave_height
+        return self._wind_wave_height  # type: ignore # this is dynamically set
 
     @property
-    def wind_wave_period(self):
+    def wind_wave_period(self) -> ObservationFloatDatum:
         """Return observed wind wave period."""
-        return self._wind_wave_period
+        return self._wind_wave_period  # type: ignore # this is dynamically set
 
     @property
-    def swell_direction(self):
+    def swell_direction(self) -> ObservationStringDatum:
         """Return observed swell direction."""
-        return self._swell_direction
+        return self._swell_direction  # type: ignore # this is dynamically set
 
     @property
-    def wind_wave_direction(self):
+    def wind_wave_direction(self) -> ObservationStringDatum:
         """Return observed wind wave direction."""
-        return self._wind_wave_direction
+        return self._wind_wave_direction  # type: ignore # this is dynamically set
 
     @property
-    def steepness(self):
+    def steepness(self) -> ObservationStringDatum:
         """Return observed wave steepness."""
-        return self._steepness
+        return self._steepness  # type: ignore # this is dynamically set
 
     @property
-    def average_wave_period(self):
+    def average_wave_period(self) -> ObservationFloatDatum:
         """Return observed average wave period."""
-        return self._average_wave_period
+        return self._average_wave_period  # type: ignore # this is dynamically set
 
     @property
-    def dominant_wave_direction(self):
+    def dominant_wave_direction(self) -> ObservationFloatDatum:
         """Return observed direction of waves at dominant period."""
-        return self._dominant_wave_direction
+        return self._dominant_wave_direction  # type: ignore # this is dynamically set

--- a/pybuoy/observation/observation_datum.py
+++ b/pybuoy/observation/observation_datum.py
@@ -1,5 +1,4 @@
-from pybuoy.const import NO_VALUE
-from pybuoy.unit_mappings import MeasurementsAndUnits, SummaryWaveSteepnessValues
+from pybuoy.unit_mappings import NO_NUMERIC_VALUE, NO_TEXT_VALUE, MeasurementsAndUnits
 
 
 class ObservationFloatDatum(float):
@@ -12,14 +11,14 @@ class ObservationFloatDatum(float):
             value (str): value of observation. (Default: "MM")
             label_unit (MeasurementsAndUnits): label and unit for value.
         """
-        self.value = None if value == NO_VALUE else float(value)
+        self.value = None if value == NO_NUMERIC_VALUE else float(value)
         self._label = label_unit["label"]
         self._unit = label_unit["unit"]
 
     def __new__(cls, value, *_):
         return (
             float.__new__(cls, value)
-            if value != NO_VALUE
+            if value != NO_NUMERIC_VALUE
             else float.__new__(cls, "nan")
         )
 
@@ -51,9 +50,7 @@ class ObservationStringDatum(str):
             label_unit (MeasurementsAndUnits): label and unit for value.
         """
         self.value = (
-            None
-            if value == NO_VALUE or value == SummaryWaveSteepnessValues.NA.value
-            else value
+            None if value == NO_NUMERIC_VALUE or value == NO_TEXT_VALUE else value
         )
         self._label = label_unit["label"]
         self._unit = label_unit["unit"]

--- a/pybuoy/observation/observations.py
+++ b/pybuoy/observation/observations.py
@@ -21,13 +21,13 @@ class BaseObservations(Generic[ObservationType]):
     def reports(self) -> list[ObservationType]:
         return self._data
 
-    @reports.setter
-    def reports(self, observation: ObservationType) -> None:
-        self._data.append(observation)
-        self._size = len(self._data)
-
     def __getitem__(self, key: int) -> ObservationType:
         return self._data[key]
+
+    def __iadd__(self, observation: ObservationType):
+        self._data.append(observation)
+        self._size = len(self._data)
+        return self
 
     def __iter__(self) -> Iterator[ObservationType]:
         return iter(self._data)

--- a/pybuoy/observation/observations.py
+++ b/pybuoy/observation/observations.py
@@ -1,36 +1,35 @@
-from typing import Iterator
+from typing import Generic, Iterator, TypeVar
 
 from pybuoy.observation import MeteorologicalObservation, WaveSummaryObservation
+from pybuoy.observation.observation import BaseObservation
+
+ObservationType = TypeVar("ObservationType", bound=BaseObservation)
 
 
-class Observations:
+class BaseObservations(Generic[ObservationType]):
     """Observations class encapsulates `Observation`s by datetime."""
 
     def __init__(
         self,
-        observations: list[MeteorologicalObservation | WaveSummaryObservation] = None,
+        observations: list[ObservationType] = None,
     ):
         # TODO: improve error handling
         self._data = observations if observations is not None else []
         self._size = len(self._data)
 
     @property
-    def reports(self) -> list[MeteorologicalObservation | WaveSummaryObservation]:
+    def reports(self) -> list[ObservationType]:
         return self._data
 
     @reports.setter
-    def reports(
-        self, observation: MeteorologicalObservation | WaveSummaryObservation
-    ) -> None:
+    def reports(self, observation: ObservationType) -> None:
         self._data.append(observation)
         self._size = len(self._data)
 
-    def __getitem__(
-        self, key: int
-    ) -> MeteorologicalObservation | WaveSummaryObservation:
+    def __getitem__(self, key: int) -> ObservationType:
         return self._data[key]
 
-    def __iter__(self) -> Iterator[MeteorologicalObservation | WaveSummaryObservation]:
+    def __iter__(self) -> Iterator[ObservationType]:
         return iter(self._data)
 
     def __repr__(self) -> str:
@@ -52,3 +51,11 @@ class Observations:
         # Convert the list to a string joined by commas
         array_as_string = ", ".join(values)
         return f"Observations([{array_as_string}])"
+
+
+class MeteorologicalObservations(BaseObservations[MeteorologicalObservation]):
+    ...
+
+
+class WaveSummaryObservations(BaseObservations[WaveSummaryObservation]):
+    ...

--- a/pybuoy/unit_mappings.py
+++ b/pybuoy/unit_mappings.py
@@ -3,6 +3,9 @@
 from enum import Enum
 from typing import TypedDict
 
+NO_NUMERIC_VALUE = "MM"
+NO_TEXT_VALUE = "N/A"
+
 
 class BaseKey(Enum):
     ...
@@ -42,7 +45,6 @@ class SummaryWaveSteepnessValues(Enum):
     VERY_STEEP = "VERY_STEEP"
     SWELL = "SWELL"
     AVERAGE = "AVERAGE"
-    NA = "N/A"
 
 
 class MeasurementsAndUnits(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ python = "^3.10"
 requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
-black = "^22.6.0"
+black = "^22.8.0"
 flake8 = "^5.0.4"
 isort = { version = "^5.10.1", extras = ["pyproject"]}
 mypy = "^0.971"
-pytest = "^7.1.2"
+pytest = "^7.1.3"
 pre-commit = "^2.20.0"
-types-requests = "^2.28.0"
+types-requests = "^2.28.9"
 
 [tool.black]
 line-length = 88

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,18 +1,58 @@
+from datetime import datetime
+from random import randrange
+
 from pybuoy import Buoy
 from pybuoy.observation import MeteorologicalObservation, WaveSummaryObservation
 
+# TODO: check values to ensure float and str are set as expected
+example_station_id = "44065"
+
 
 def test_realtime_meterological_data(test_pybuoy: Buoy):
-    example_station_id = "44065"
     response = test_pybuoy.realtime.get(station_id=example_station_id)
     for record in response:
         assert isinstance(record, MeteorologicalObservation)
         assert len(record.__dict__.keys()) == 15
 
+    random_record = response[randrange(len(response.reports))]
+
+    assert (
+        hasattr(random_record, "datetime") and type(random_record.datetime) is datetime
+    )
+    assert hasattr(random_record, "wind_direction")
+    assert hasattr(random_record, "wind_speed")
+    assert hasattr(random_record, "wind_gust")
+    assert hasattr(random_record, "wave_height")
+    assert hasattr(random_record, "dominant_wave_period")
+    assert hasattr(random_record, "average_wave_period")
+    assert hasattr(random_record, "wave_direction")
+    assert hasattr(random_record, "sea_level_pressure")
+    assert hasattr(random_record, "pressure_tendency")
+    assert hasattr(random_record, "air_temperature")
+    assert hasattr(random_record, "water_temperature")
+    assert hasattr(random_record, "dewpoint_temperature")
+    assert hasattr(random_record, "visibility")
+    assert hasattr(random_record, "tide")
+
 
 def test_realtime_wave_summary_data(test_pybuoy: Buoy):
-    example_station_id = "44065"
     response = test_pybuoy.realtime.get(station_id=example_station_id, dataset="spec")
     for record in response:
         assert isinstance(record, WaveSummaryObservation)
         assert len(record.__dict__.keys()) == 11
+
+    random_record = response[randrange(len(response.reports))]
+
+    assert (
+        hasattr(random_record, "datetime") and type(random_record.datetime) is datetime
+    )
+    assert hasattr(random_record, "significant_wave_height")
+    assert hasattr(random_record, "swell_height")
+    assert hasattr(random_record, "swell_period")
+    assert hasattr(random_record, "wind_wave_height")
+    assert hasattr(random_record, "wind_wave_period")
+    assert hasattr(random_record, "swell_direction")
+    assert hasattr(random_record, "wind_wave_direction")
+    assert hasattr(random_record, "steepness")
+    assert hasattr(random_record, "average_wave_period")
+    assert hasattr(random_record, "dominant_wave_direction")

--- a/tests/test_stations.py
+++ b/tests/test_stations.py
@@ -3,6 +3,12 @@ from random import randrange
 from pybuoy import Buoy
 from pybuoy.mixins.parser import XmlToDict
 
+example_station_id = "44065"
+
+
+def find_buoy(buoys: list[XmlToDict], station_id: str):
+    return next((buoy for buoy in buoys if buoy.get("id", None) == station_id), None)
+
 
 def test_activestations_from_xml(test_pybuoy: Buoy):
     response = test_pybuoy.stations.get_active()
@@ -16,6 +22,35 @@ def test_activestations_from_xml(test_pybuoy: Buoy):
     assert "name" in random_station
     assert "owner" in random_station
     assert "type" in random_station
-    assert "met" in random_station
-    assert "currents" in random_station
-    assert "waterquality" in random_station
+
+    is_type_tao = True if random_station.get("type", None) == "tao" else False
+    if not is_type_tao:
+        assert "met" in random_station
+        assert "currents" in random_station
+        assert "waterquality" in random_station
+    else:
+        assert random_station.get("type") == "tao"
+
+
+def test_rockaway_beach_buoy(test_pybuoy: Buoy):
+    response = test_pybuoy.stations.get_active()
+
+    rockaway_buoy = find_buoy(response, example_station_id)
+    assert isinstance(rockaway_buoy, XmlToDict)
+
+    assert "id" in rockaway_buoy
+    assert "lat" in rockaway_buoy
+    assert "lon" in rockaway_buoy
+    assert "name" in rockaway_buoy
+    assert "owner" in rockaway_buoy
+    assert "type" in rockaway_buoy
+    assert "met" in rockaway_buoy
+    assert "currents" in rockaway_buoy
+    assert "waterquality" in rockaway_buoy
+
+    expected_lat = "40.369"
+    expected_lon = "-73.703"
+    expected_name = "New York Harbor Entrance - 15 NM SE of Breezy Point , NY"
+    assert rockaway_buoy.get("lat") == expected_lat
+    assert rockaway_buoy.get("lon") == expected_lon
+    assert rockaway_buoy.get("name") == expected_name


### PR DESCRIPTION
## Description

Improve type support for `realtime.get`.

### Demo

1. When dataset="spec", response is defined as `WaveSummaryObservations`:
    
    <img width="694" alt="wave_type_demo" src="https://user-images.githubusercontent.com/47502769/188498847-2cc76621-6f03-42a9-9e0e-b82a1460e391.png">

2. When dataset="txt", response is defined as `MeteorologicalObservations`:
    
    <img width="694" alt="met_type_demo" src="https://user-images.githubusercontent.com/47502769/188498857-d35c9dba-e095-432d-bd7d-b3e3bee5bea8.png">

3. All responses from this API are iterable:

    <img width="810" alt="iteration_met_support_demo" src="https://user-images.githubusercontent.com/47502769/188499480-f296582a-bdf8-444b-ae33-42b3e92f804c.png">

4. Attributes for every `Observation` can be statically inferred from IDE:

    <img width="810" alt="met_obs_type_demo" src="https://user-images.githubusercontent.com/47502769/188499400-3c4e4228-5331-4bbd-915b-668404da89f2.png">

    <img width="790" alt="show_datum_type" src="https://user-images.githubusercontent.com/47502769/188500871-b48a41fc-8dc8-4735-b570-22f388772394.png">

    <img width="870" alt="datum_attributes_demo" src="https://user-images.githubusercontent.com/47502769/188501136-79d9d29f-6ff0-4579-be16-c2e3003bb0d4.png">

### Summary of Changes
- [x] Improve type support with tools like `mypy`.
- [x] Update tests to check for expected attributes.
- [x] Append record to `Observations` with `+=` syntax.

### Documentation

- [x] Update CHANGELOG to incorporate changes introduced by this PR for next release.
- [x] Remove unnecessary `isinstance` checks from example/get_realtime_data.py.

## Related Issues

Improves https://github.com/clairBuoyant/pybuoy/issues/8