### PR TITLE
fix(forecasts): support JSON by replacing `NaN` with `None` as default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+Fix
+~~~
+
+- **Forecasts**: ``.value`` of ``ForecastObservation`` will default to ``None`` (type: NoneType)
+  when datum missing instead of ``nan`` (type: float) to support ``JSON``.
+
 0.5.0 (2023-03-04)
 ------------------
 

--- a/pybuoy/api/forecasts.py
+++ b/pybuoy/api/forecasts.py
@@ -8,6 +8,7 @@ import lxml.etree as ET  # type: ignore
 from pybuoy.api.base import ApiBase
 from pybuoy.const import API_PATH, Endpoints
 from pybuoy.observation import ForecastObservation, ForecastObservations
+from pybuoy.unit_mappings import NO_NUMERIC_VALUE
 
 
 class Forecasts(ApiBase):
@@ -105,7 +106,7 @@ class Forecasts(ApiBase):
             ),
             "water-state": ("significant",),
         }
-        default_val = {"value": "nan"}
+        default_val = {"value": NO_NUMERIC_VALUE}
         groupedby_timestamp: dict[str, dict] = defaultdict(
             lambda: defaultdict(
                 dict,


### PR DESCRIPTION
Hotfix: `JSON` support for `forecasts` values.

---

## Summary of Changes

- [x] `Forecasts`: replace `NaN` with `None` only if value is not provided for given date.